### PR TITLE
Add basic wedding website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+uploads/
+hochzeit.db
+instance/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# hochzeit
+# Hochzeit
+
+Eine einfache Flask-Anwendung für eine Hochzeitswebseite. Sie ermöglicht RSVP-Antworten, Fotouploads über einen QR-Code und eine Admin-Oberfläche.
+
+## Setup
+
+1. Abhängigkeiten installieren:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Datenbank konfigurieren. Standardmäßig wird eine lokale SQLite-Datei verwendet. Um MySQL zu nutzen, setze die Umgebungsvariable `DATABASE_URL`, z. B.:
+   ```bash
+   export DATABASE_URL=mysql://user:pass@localhost/hochzeit
+   ```
+
+3. Admin-Benutzer anlegen:
+   ```bash
+   python create_admin.py
+   ```
+
+4. Anwendung starten:
+   ```bash
+   flask --app app run
+   ```
+
+## Tests
+
+```bash
+pytest
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,98 @@
+from flask import Flask, render_template, request, redirect, url_for
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, UserMixin, login_user, login_required, logout_user
+from werkzeug.security import generate_password_hash, check_password_hash
+import os
+import uuid
+from datetime import datetime
+
+app = Flask(__name__)
+app.config.from_object('config.Config')
+
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'admin_login'
+
+class Admin(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+class Guest(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(120), nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+    attending = db.Column(db.Boolean)
+    comment = db.Column(db.Text)
+    upload_token = db.Column(db.String(36), unique=True, default=lambda: str(uuid.uuid4()))
+
+class Photo(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    guest_id = db.Column(db.Integer, db.ForeignKey('guest.id'))
+    filename = db.Column(db.String(200))
+    uploaded_at = db.Column(db.DateTime, default=datetime.utcnow)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return Admin.query.get(int(user_id))
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/rsvp', methods=['GET', 'POST'])
+def rsvp():
+    if request.method == 'POST':
+        name = request.form.get('name')
+        email = request.form.get('email')
+        attending = request.form.get('attending') == 'yes'
+        comment = request.form.get('comment')
+        guest = Guest(name=name, email=email, attending=attending, comment=comment)
+        db.session.add(guest)
+        db.session.commit()
+        return redirect(url_for('index'))
+    return render_template('rsvp.html')
+
+@app.route('/upload/<token>', methods=['GET', 'POST'])
+def upload(token):
+    guest = Guest.query.filter_by(upload_token=token).first_or_404()
+    if request.method == 'POST':
+        file = request.files['photo']
+        if file:
+            filename = f"{uuid.uuid4()}_{file.filename}"
+            upload_path = os.path.join('uploads', filename)
+            os.makedirs('uploads', exist_ok=True)
+            file.save(upload_path)
+            photo = Photo(guest_id=guest.id, filename=filename)
+            db.session.add(photo)
+            db.session.commit()
+            return redirect(url_for('upload', token=token))
+    return render_template('upload.html', guest=guest)
+
+@app.route('/admin/login', methods=['GET', 'POST'])
+def admin_login():
+    if request.method == 'POST':
+        username = request.form.get('username')
+        password = request.form.get('password')
+        admin = Admin.query.filter_by(username=username).first()
+        if admin and check_password_hash(admin.password_hash, password):
+            login_user(admin)
+            return redirect(url_for('admin_dashboard'))
+    return render_template('login.html')
+
+@app.route('/admin/logout')
+@login_required
+def admin_logout():
+    logout_user()
+    return redirect(url_for('index'))
+
+@app.route('/admin')
+@login_required
+def admin_dashboard():
+    guests = Guest.query.all()
+    photos = Photo.query.all()
+    return render_template('admin.html', guests=guests, photos=photos)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,6 @@
+import os
+
+class Config:
+    SECRET_KEY = os.environ.get('SECRET_KEY', 'dev-secret-key')
+    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL', 'sqlite:///hochzeit.db')
+    SQLALCHEMY_TRACK_MODIFICATIONS = False

--- a/create_admin.py
+++ b/create_admin.py
@@ -1,0 +1,13 @@
+from getpass import getpass
+from app import app, db, Admin
+from werkzeug.security import generate_password_hash
+
+username = input('Admin Benutzername: ')
+password = getpass('Admin Passwort: ')
+
+with app.app_context():
+    db.create_all()
+    admin = Admin(username=username, password_hash=generate_password_hash(password))
+    db.session.add(admin)
+    db.session.commit()
+    print('Admin erstellt.')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask==2.3.2
+Flask_SQLAlchemy==3.0.5
+Flask_Login==0.6.2
+mysqlclient==2.1.1
+Werkzeug==2.3.4
+pytest

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+    <title>Admin Dashboard</title>
+</head>
+<body>
+    <h1>Admin Dashboard</h1>
+    <h2>Gäste</h2>
+    <ul>
+        {% for guest in guests %}
+        <li>{{ guest.name }} - {{ 'kommt' if guest.attending else 'kommt nicht' }} - {{ guest.comment }}</li>
+        {% endfor %}
+    </ul>
+
+    <h2>Fotos</h2>
+    <ul>
+        {% for photo in photos %}
+        <li>{{ photo.filename }} von Gast ID {{ photo.guest_id }}</li>
+        {% endfor %}
+    </ul>
+
+    <p><a href="{{ url_for('admin_logout') }}">Logout</a></p>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+    <title>Unsere Hochzeit</title>
+</head>
+<body>
+    <h1>Willkommen zu unserer Hochzeit</h1>
+    <p><a href="{{ url_for('rsvp') }}">Sag uns ob du kommst</a></p>
+</body>
+</html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+    <title>Admin Login</title>
+</head>
+<body>
+    <h1>Admin Login</h1>
+    <form method="post">
+        Benutzername: <input type="text" name="username"><br>
+        Passwort: <input type="password" name="password"><br>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>

--- a/templates/rsvp.html
+++ b/templates/rsvp.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+    <title>RSVP</title>
+</head>
+<body>
+    <h1>RSVP</h1>
+    <form method="post">
+        Name: <input type="text" name="name"><br>
+        Email: <input type="email" name="email"><br>
+        Kommst du?
+        <select name="attending">
+            <option value="yes">Ja</option>
+            <option value="no">Nein</option>
+        </select><br>
+        Kommentar: <textarea name="comment"></textarea><br>
+        <button type="submit">Senden</button>
+    </form>
+</body>
+</html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+    <title>Foto hochladen</title>
+</head>
+<body>
+    <h1>Foto hochladen</h1>
+    <p>Hallo {{ guest.name }}</p>
+    <form method="post" enctype="multipart/form-data">
+        <input type="file" name="photo">
+        <button type="submit">Hochladen</button>
+    </form>
+</body>
+</html>

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,16 @@
+import pytest
+from app import app, db
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    with app.app_context():
+        db.create_all()
+    with app.test_client() as client:
+        yield client
+
+
+def test_index(client):
+    response = client.get('/')
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- set up Flask app with RSVP, photo uploads via QR code token, and admin dashboard
- default to SQLite but allow MySQL via `DATABASE_URL`
- include basic test for homepage

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898bf5c14388326939933ed2663523e